### PR TITLE
chore(release): Add project metadata to pom.xml

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>cibseven-bpm-jgiven</artifactId>
   <packaging>jar</packaging>
 
+  <name>CIB seven BPM JGiven</name>
+  <description>JGiven BPM testing library for CIB seven process engine</description>
+  <url>https://github.com/cibseven-community-hub/cibseven-bpm-jgiven/</url>
+
   <dependencies>
     <dependency>
       <groupId>io.toolisticon.testing</groupId>


### PR DESCRIPTION
Includes the name, description, and URL for the CIB seven BPM JGiven testing library in the pom.xml file. This enhances project documentation and provides better context for users and contributors.